### PR TITLE
Goblin should have the abstract keyword

### DIFF
--- a/src/main/entities/Goblin.java
+++ b/src/main/entities/Goblin.java
@@ -6,7 +6,7 @@ import entities.interfaces.Talkable;
  * Goblin.txt abstract class, every goblin is talkable
  */
 
-public class Goblin extends Interactable implements Talkable {
+public abstract class Goblin extends Interactable implements Talkable {
 
     /**
      * Construct a Goblin


### PR DESCRIPTION
Goblin is an abstract class by its defintion, and concrete classes like RiddleGoblin inherit from it.

So Goblin needs to have the abstract keyword and have:
`public abstract class Goblin extends Interactable implements Talkable`

and RiddleGoblin currently has: 
`public class RiddleGoblin extends Goblin`

we are missing the abstract keyword for Goblin.

For a similar interactable example, Door is an abstract class 
`public abstract class Door extends Interactable implements Unlockable`

and VaultDoor inherits from Door, so its a concrete class, and currently we have:
`public class VaultDoor extends Door`


