### PR TITLE
Fixed the tree harvestng type checking and error response

### DIFF
--- a/src/main/entities/Tree.java
+++ b/src/main/entities/Tree.java
@@ -27,6 +27,7 @@ public class Tree extends Interactable implements Harvestable {
      * @param player the harvesting player
      * @return the harvested resources
      */
+    @Override
     public String harvest(Player player, int toolDamage){
         if (!(this.isCompleted())) {
             int remaining = this.getProperty(InteractableProperties.RES_STORE_NAME.name()).getInteger();

--- a/src/main/interfaceadapters/commands/ChopCommand.java
+++ b/src/main/interfaceadapters/commands/ChopCommand.java
@@ -19,7 +19,7 @@ public class ChopCommand extends Command {
        this.chop = new Chop();
    }
    @Override
-    public String execute(HashMap<String, Interactable> args) {
+   public String execute(HashMap<String, Interactable> args) {
         return chop.chopHarvestable(args);
     }
 }

--- a/src/main/usecases/Chop.java
+++ b/src/main/usecases/Chop.java
@@ -22,16 +22,20 @@ public class Chop {
      */
     public String chopHarvestable(HashMap<String, Interactable> args) {
         String tool = "tool"; String target = "target";
-        if(args.get(target) instanceof Harvestable && args.get(tool) instanceof CanChop && args.get(tool) instanceof Item) {
-            if(!(((Item) args.get(tool)).getHeldBy() == null)){
-                // harvest the tree using the player that's holding the axe
-                return ((Harvestable) args.get(target)).harvest((Player) ((Item) args.get(tool)).getHeldBy(),
-                        args.get(tool).getProperty(InteractableProperties.CHOP_DMG_NAME.name()).getInteger());
+        if(args.get(tool) != null) {
+            if(args.get(target) instanceof Harvestable && args.get(tool) instanceof CanChop && args.get(tool) instanceof Item) {
+                if(!(((Item) args.get(tool)).getHeldBy() == null)){
+                    // harvest the tree using the player that's holding the axe
+                    return ((Harvestable) args.get(target)).harvest((Player) ((Item) args.get(tool)).getHeldBy(),
+                            args.get(tool).getProperty(InteractableProperties.CHOP_DMG_NAME.name()).getInteger());
+                } else {
+                    return "You don't hold that";
+                }
             } else {
-                return "You don't hold that";
+                return "You cannot harvest that!";
             }
         } else {
-            return "You cannot harvest that!";
+            return "That tool does not seem to exist";
         }
     }
 }


### PR DESCRIPTION
Currently, the type check for harvesting something (such as a tree as that is all we have at the moment) was flawed. If you tried to harvest a tree with a weapon that did not exist it would raise the wrong error message. This has been resolved with an extra type check. Thank you to @MichelleChernyi for pointing this out.